### PR TITLE
Add CSV default input option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ pip install -r requirements.txt
 ## Usage
 
 
-Prepare a mapping of municipality names to URLs in `municipalities.json`
+Prepare a mapping of municipality names to URLs in `municipalities.csv`
 (a sample file is provided). Then run the crawler via the command line:
 
 ```bash
-python -m crawler.crawler --input municipalities.json --output fees.xlsx
+python -m crawler.crawler --input municipalities.csv --output fees.xlsx
 ```
 
 You can also launch a small GUI to select files interactively:

--- a/crawler/crawler.py
+++ b/crawler/crawler.py
@@ -177,8 +177,11 @@ def run_gui(args):
 
 def main():
     parser = argparse.ArgumentParser(description="Municipal fee crawler")
-    parser.add_argument('--input', default='municipalities.json',
-                        help='JSON or CSV file with municipality URL mapping')
+    parser.add_argument(
+        '--input',
+        default='municipalities.csv',
+        help='JSON or CSV file with municipality URL mapping'
+    )
     parser.add_argument('--output', default='municipal_fees.xlsx',
                         help='Excel file to write results to')
     parser.add_argument('--gui', action='store_true',


### PR DESCRIPTION
## Summary
- default CLI input file to `municipalities.csv`
- update README usage examples to match new default

## Testing
- `python -m unittest discover -s tests -v`