### PR TITLE
Add crawler tests and README hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ The script writes the collected data to the specified Excel file.
 
 ## Tests
 
-Basic tests use mocked network calls so no internet connection is
-required:
+Basic tests use mocked network calls and PDF parsing so no internet
+connection or external dependencies are required:
 
 
 ```bash

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -42,31 +42,65 @@ class DummyResp:
         pass
 
 class CrawlerTests(unittest.TestCase):
-    @patch('crawler.crawler.pd')
-    @patch('crawler.crawler.requests')
-    def test_html_parsing(self, mock_requests, mock_pd):
-        mock_requests.get.return_value = DummyResp(text=SAMPLE_HTML)
-        mock_pd.DataFrame.side_effect = lambda rows: DummyDF(rows)
-        cr = crawler.MunicipalCrawler({'Test': 'http://example.com'})
-        df = cr.run()
-        row = df.iloc[0]
-        self.assertEqual(row['food_control_hourly_rate'], 1200.0)
-        self.assertEqual(row['food_control_billing_model'], 'efterhands')
-        self.assertEqual(row['building_permit_hourly_rate'], 900.0)
+    def setUp(self):
+        self.crawler = crawler.MunicipalCrawler({})
+
+    def test_parse_hourly_rate(self):
+        self.assertEqual(
+            self.crawler.parse_hourly_rate('Timtaxa 1200 kr', r'(\d+[\,\.]?\d*)'),
+            1200.0,
+        )
+        self.assertEqual(
+            self.crawler.parse_hourly_rate('Timtaxa 900,5 kr', r'(\d+[\,\.]?\d*)'),
+            900.5,
+        )
+        self.assertIsNone(
+            self.crawler.parse_hourly_rate('Ingen taxa', r'(\d+[\,\.]?\d*)')
+        )
+
+    def test_parse_billing_model(self):
+        self.assertEqual(
+            self.crawler.parse_billing_model('Vi använder efterhandsdebitering.'),
+            'efterhands',
+        )
+        self.assertEqual(
+            self.crawler.parse_billing_model('Forskottsdebitering tillämpas.'),
+            'forskott',
+        )
+        self.assertIsNone(
+            self.crawler.parse_billing_model('Okänt system.')
+        )
 
     @patch('crawler.crawler.pd')
     @patch('crawler.crawler.PdfReader')
+    @patch('crawler.crawler.requests.get')
     @patch('crawler.crawler.requests')
-    def test_pdf_parsing(self, mock_requests, mock_reader, mock_pd):
-        mock_requests.get.return_value = DummyResp(content=b'pdfbytes')
+    def test_overall_crawl(self, mock_requests, mock_get, mock_reader, mock_pd):
+        def fake_get(url, timeout=10):
+            if url.endswith('.pdf'):
+                return DummyResp(content=b'pdfbytes')
+            return DummyResp(text=SAMPLE_HTML)
+
+        mock_get.side_effect = fake_get
         mock_reader.return_value.pages = [Mock(extract_text=lambda: SAMPLE_PDF_TEXT)]
         mock_pd.DataFrame.side_effect = lambda rows: DummyDF(rows)
-        cr = crawler.MunicipalCrawler({'PDFTest': 'http://example.com/test.pdf'})
+
+        urls = {
+            'HTMLTown': 'http://example.com/html',
+            'PDFTown': 'http://example.com/file.pdf',
+        }
+        cr = crawler.MunicipalCrawler(urls)
         df = cr.run()
-        row = df.iloc[0]
-        self.assertEqual(row['food_control_hourly_rate'], 1300.0)
-        self.assertEqual(row['food_control_billing_model'], 'forskott')
-        self.assertIsNone(row['building_permit_hourly_rate'])
+        row_html = df.iloc[0]
+        row_pdf = df.iloc[1]
+
+        self.assertEqual(row_html['food_control_hourly_rate'], 1200.0)
+        self.assertEqual(row_html['food_control_billing_model'], 'efterhands')
+        self.assertEqual(row_html['building_permit_hourly_rate'], 900.0)
+
+        self.assertEqual(row_pdf['food_control_hourly_rate'], 1300.0)
+        self.assertEqual(row_pdf['food_control_billing_model'], 'forskott')
+        self.assertIsNone(row_pdf['building_permit_hourly_rate'])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- improve test coverage for `crawler.crawler`
- mock `requests.get` and `PyPDF2` for crawling tests
- mention how tests run in README

## Testing
- `python -m unittest -v tests/test_crawler.py`